### PR TITLE
Switch to svelte v3 and add size outputs for plain and gz

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "terser-playground",
   "version": "1.0.0",
   "devDependencies": {
+    "gzip-js": "^0.3.2",
     "npm-run-all": "^4.1.3",
     "rollup": "^0.66.2",
     "rollup-plugin-commonjs": "^9.1.8",
@@ -9,7 +10,7 @@
     "rollup-plugin-svelte": "^4.3.1",
     "rollup-plugin-terser": "^3.0.0",
     "sirv-cli": "^0.2.2",
-    "svelte": "^2.13.5"
+    "svelte": "^3.0.0-alpha16"
   },
   "scripts": {
     "build": "rollup -c",

--- a/src/App.html
+++ b/src/App.html
@@ -1,7 +1,56 @@
-<div class="playground">
-	<textarea class="input" bind:value=input></textarea>
-	<textarea class="output" class:error readonly value={error ? error.message : code}></textarea>
-</div>
+<script>
+	import { beforeUpdate } from 'svelte';
+	import { zip } from 'gzip-js';
+
+	let input = 'const answer = 42;';
+	let lastInput = input;
+	let error = null;
+	let output = '';
+	let inputGzLen = 0;
+	let outputGzLen = 0;
+
+	$: inputGzLen = zip(input).length;
+	$: outputGzLen = zip(output || '').length;
+
+	function fmt(num) {
+		if (num < 0) return `${num}`.substr(0, 5);
+		num = Math.round(num * 100) / 100;
+		return `${num}`.replace(/(\d)(?=(\d\d\d)+(?!\d))/g, "$1,");
+	}
+
+	const worker = new Worker('worker.js');
+
+	let uid = 1;
+	let current_token;
+
+	const minify = () => {
+		lastInput = input;
+		if (!input) {
+			output = '';
+		}
+		
+		else {
+			const token = uid++;
+			worker.postMessage({ input, token });
+		}
+	};
+
+	worker.addEventListener('message', event => {
+		if (event.data.ready) {
+			minify();
+		}
+
+		else if (event.data.token === current_token) {
+			output = event.data.code || '';
+			error = event.data.error;
+			outputGzLen = zip(output || '').length;
+		}
+	});
+
+	beforeUpdate(() => {
+		if (input !== lastInput) minify();
+	});
+</script>
 
 <style>
 	.playground {
@@ -9,6 +58,7 @@
 		height: 100%;
 		display: grid;
 		grid-template-columns: 1fr 1fr;
+		grid-template-rows: 1fr 1em;
 		grid-gap: 0.5em;
 	}
 
@@ -29,46 +79,8 @@
 	}
 </style>
 
-<script>
-	export default {
-		data() {
-			return {
-				input: 'const answer = 42;',
-				code: ''
-			};
-		},
-
-		oncreate() {
-			const worker = new Worker('worker.js');
-
-			const callbacks = {};
-			let uid = 1;
-			let current_token;
-
-			const minify = () => {
-				const { input } = this.get();
-				const token = uid++;
-				worker.postMessage({ input, token });
-			};
-
-			worker.addEventListener('message', event => {
-				if (event.data.ready) {
-					this.set({ ready: true });
-					minify();
-				}
-
-				else if (event.data.token === current_token) {
-					this.set({
-						code: event.data.code,
-						warnings: event.data.warnings,
-						error: event.data.error
-					});
-				}
-			});
-
-			this.on('state', async ({ changed, current }) => {
-				if (changed.input) minify();
-			});
-		}
-	};
-</script>
+<div class="playground">
+	<textarea class="input" bind:value={input}></textarea>
+	<textarea class="output" class:error readonly value={error ? error.message : output}></textarea>
+	<div>{fmt(input.length / 1024)} KiB plain : {fmt(inputGzLen / 1024)} KiB gzipped</div><div>{error ? '' : `${fmt(output.length / 1024)} KiB plain : ${fmt(outputGzLen / 1024)} KiB gzipped`}</div>
+</div>


### PR DESCRIPTION
I was looking about for an easy way to check minified sizes on some es-after-5 code, and behold, there's a @Rich-Harris project for that!

I wanted to try out svelte v3, so I ported this, and apart from being a little var-y in this case, it's really slick! The only weird-ish thing is not being able to observe a value to trigger some code. I tried to follow the RFCs, but I missed a bit there in the middle. Was there ever a proposal along the lines of `$: input => minitfy();`? That may be a bit too silly/magical, but it's a fairly common pattern for observers in lots of my code. You could even go crazy and allow for old values to be collected in a second param and subscriptions handled by destructure on the first. But again, that may peg the silly scale.

I also added KiB outputs for plain text and gzip at level 6 for both input and output.